### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,29 @@
 BASEDIR     = $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 TMP_DIR      = $(BASEDIR)/tmp
-REVEAL_SRC = $(BASEDIR)/reveal/
-WEBAPP_SRC  = $(REVEAL_SRC)/webapp/
-WEBAPI_SRC  = $(REVEAL_SRC)/webapi/
-STATIC_DIR   = $(BASEDIR)/data-directories/static/
-DISTDIR     = $(STATIC_DIR)dist/
-PLUGINDIR   = $(STATIC_DIR)plugins/
+REVEAL_SRC = $(BASEDIR)/reveal
+WEBAPP_SRC  = $(REVEAL_SRC)/webapp
+WEBAPI_SRC  = $(REVEAL_SRC)/webapi
+STATIC_DIR   = $(BASEDIR)/data-directories/static
+DISTDIR     = $(STATIC_DIR)dist
+PLUGINDIR   = $(STATIC_DIR)plugins
 
 
-DOCKER_WEBAPP                   = $(BASEDIR)/services/web/
-DOCKER_WEBAPP_SRC               = $(BASEDIR)/services/web/reveal/
-REPORT_DIR                      = $(BASEDIR)/data-directories/reports/
-DOCKER_REPORT_DIR               = $(BASEDIR)/services/web/reports/
-UPLOAD_DIR                      = $(BASEDIR)/data-directories/uploads/
-DOCKER_UPLOAD_DIR               = $(BASEDIR)/services/web/uploads/
-UPDATE_DATA_DIR                 = $(BASEDIR)/data-directories/update-data/
-DOCKER_UPDATE_DATA_DIR          = $(BASEDIR)/services/web/update-data/
-DOCKER_WEB_STATIC_DATA_DIR      = $(BASEDIR)/services/web/static/
+DOCKER_WEBAPP                   = $(BASEDIR)/services/web
+DOCKER_WEBAPP_SRC               = $(BASEDIR)/services/web/reveal
+REPORT_DIR                      = $(BASEDIR)/data-directories/reports
+DOCKER_REPORT_DIR               = $(BASEDIR)/services/web/reports
+UPLOAD_DIR                      = $(BASEDIR)/data-directories/uploads
+DOCKER_UPLOAD_DIR               = $(BASEDIR)/services/web/uploads
+UPDATE_DATA_DIR                 = $(BASEDIR)/data-directories/update-data
+DOCKER_UPDATE_DATA_DIR          = $(BASEDIR)/services/web/update-data
+DOCKER_WEB_STATIC_DATA_DIR      = $(BASEDIR)/services/web/static
 
-DOCKER_NGINX_STATIC_DATA_DIR    = $(BASEDIR)/services/nginx/static/
-DOCKER_NGINX                    = $(BASEDIR)/services/nginx/
+DOCKER_NGINX_STATIC_DATA_DIR    = $(BASEDIR)/services/nginx/static
+DOCKER_NGINX                    = $(BASEDIR)/services/nginx
 
-DOCKER_WEBAPI                   = $(BASEDIR)/services/api/
-DOCKER_WEBAPI_SRC               = $(BASEDIR)/services/api/reveal/
+DOCKER_WEBAPI                   = $(BASEDIR)/services/api
+DOCKER_WEBAPI_SRC               = $(BASEDIR)/services/api/reveal
 
 TMP_ADMIN_LTE_URL = https://github.com/ColorlibHQ/AdminLTE/archive/refs/tags/v3.2.0.zip
 TMP_ADMIN_LTE_ZIP = "admin-lte.zip"

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ endif
 tmp:
 	@$(shell mkdir -p $(TMP_ADMIN_LTE_DIR) )
 	@$(shell mkdir -p $(UPLOAD_DIR) )
+	@$(shell mkdir -p $(STATIC_DIR) )
 	./download-dependencies.sh
 
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ TMP_ADMIN_LTE_DIR = "$(TMP_DIR)/admin-lte"
 TMP_ADMIN_LTE_DIST = "$(TMP_DIR)/AdminLTE-3.2.0/dist"
 TMP_ADMIN_LTE_PLUGINS = "$(TMP_DIR)/AdminLTE-3.2.0/plugins"
 
+# Check if docker compose (v2) is available
+ifeq ($(shell docker compose version 2>/dev/null),)
+  DOCKER_COMPOSE := docker-compose
+else
+  DOCKER_COMPOSE := docker compose
+endif
+
 
 tmp:
 	@$(shell mkdir -p $(TMP_ADMIN_LTE_DIR) )
@@ -68,20 +75,20 @@ build: tmp
 	@$(shell cp -r $(STATIC_DIR) $(DOCKER_NGINX))
 	@$(shell cp -r $(REVEAL_SRC) $(DOCKER_WEBAPP))
 	@$(shell cp -r $(REVEAL_SRC) $(DOCKER_WEBAPI))
-	docker-compose build
+	$(DOCKER_COMPOSE) build
 
 run:
-	docker-compose up
+	$(DOCKER_COMPOSE) up
 
 stop:
-	docker-compose down -v
+	$(DOCKER_COMPOSE) down -v
 
 init-db:
-	docker-compose exec webapp flask -e webapp.env user create admin
-	docker-compose exec webapp flask -e webapp.env import eol "/app/update-data/win-support-dates.csv"
+	$(DOCKER_COMPOSE) exec webapp flask -e webapp.env user create admin
+	$(DOCKER_COMPOSE) exec webapp flask -e webapp.env import eol "/app/update-data/win-support-dates.csv"
 
 clear-data:
-	docker-compose exec webapp flask -e webapp.env db clear
+	$(DOCKER_COMPOSE) exec webapp flask -e webapp.env db clear
 
 reset-admin:
-	docker-compose exec webapp flask -e webapp.env user reset admin
+	$(DOCKER_COMPOSE) exec webapp flask -e webapp.env user reset admin


### PR DESCRIPTION
This increases the compatibility of the Makefile so that the newer `docker compose` can be used and that it also works on macOS.

4c671ad7f1e21cc75c76007bb1b24a2f0562435d also fixes the bug that the container needed to be built two times to make the CSS work. 