### PR TITLE
Fix reveal to work on other ports than 443

### DIFF
--- a/reveal/config.py
+++ b/reveal/config.py
@@ -39,6 +39,10 @@ class AppConfig(object):
 
     # Enable protection agains *Cross-site Request Forgery (CSRF)*
     CSRF_ENABLED = True
+    # Do not strictly check the referrer header
+    # This check will fail when the forwarded docker nginx port is different to 443
+    WTF_CSRF_SSL_STRICT = False
+    
     # import secrets
     # secrets.token_hex(32)
     CSRF_SESSION_KEY = os.environ.get('CSRF_SESSION_KEY') or \


### PR DESCRIPTION
Strict Referrer checks are disabled. In the docker setup the requests are reverse proxied through the nginx container. If the port mapping in the docker-compose file is changed, e.g. `8443:443`, the Browser will send `[Host]:8443` in the Referrer-Header. Because of the reverse-proxy, the request is received by the webapp container on port `443`. Since both does not match, an error message is triggered by the csrf extension. https://github.com/wtforms/flask-wtf/blob/main/src/flask_wtf/csrf.py#L273

See also:
https://pythonhosted.org/Flask-WTF/config.html