### PR TITLE
Remove static volume from compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     command: gunicorn --bind 0.0.0.0:8000 --workers=2 --timeout=300 reveal.app:app
     volumes:
       - ./services/web/:/app
-      - static_volume:/app/static/
       - upload_volume:/app/uploads/
       - report_volume:/app/reports/
       - update-data:/app/update-data/
@@ -28,9 +27,6 @@ services:
       - postgres_data:/var/lib/postgresql/data/
   nginx:
     build: ./services/nginx
-    volumes:
-      - static_volume:/app/static/
-      - ssl_volume:/app/ssl/
     ports:
       - "80:80"
       - "81:81"
@@ -41,7 +37,6 @@ services:
       - webapi
 volumes:
   postgres_data:
-  static_volume:
   upload_volume:
   report_volume:
   update-data:


### PR DESCRIPTION
Using the `static_volume` in the compose file might introduce bugs that appear when the containers are rebuilt.

During the build process of the containers, the contents of `static` folders are copied into the container. By declaring the `static_volume` in the docker-compose file, the files inside the container are implicitly copied into the volume during the first start of the container, but only if the volume is empty. 
After that, the following series of events would cause a problem:
1. The content of the volume is modified
2. Containers are rebuilt from scratch
3. `docker compose up`
4. The files in the static volume are still in the state after step 1.

This can only be reset if the volumes are also deleted before step 3, which is quite confusing.
